### PR TITLE
Added options for instructions at the top and bottom of custom meta boxe...

### DIFF
--- a/css/supercpt.css
+++ b/css/supercpt.css
@@ -11,7 +11,7 @@
 	border:1px solid #ffe1e0 !important;
 }
 
-.scpt-field-wrap {
+.scpt-field-wrap, .scpt-meta-instructions {
 	margin: 10px 0;
 }
 label.scpt-meta-label {

--- a/includes/class-super-custom-post-meta.php
+++ b/includes/class-super-custom-post-meta.php
@@ -209,7 +209,7 @@ class Super_Custom_Post_Meta {
 				$box['page'],
 				$box['context'],
 				$box['priority'],
-				$box['fields']
+				$box
 			);
 		}
 	}
@@ -223,8 +223,14 @@ class Super_Custom_Post_Meta {
 	 * @return void
 	 * @author Matthew Boynes
 	 */
-	public function meta_html( $post, $fields ) {
-		$fields = $fields['args'];
+	public function meta_html( $post, $callback_args ) {
+		$box = $callback_args['args'];
+		
+		if ( $box['instructions_pre'] ) {
+			echo '<div class="scpt-meta-instructions">' . $box['instructions_pre'] . '</div>';	
+		}
+
+		$fields = $box['fields'];
 		// Use nonce for verification
 		if ( ! $this->printed_nonce ) {
 			wp_nonce_field( plugin_basename( __FILE__ ), sprintf( $this->nonce_key, $this->type ) );
@@ -237,6 +243,11 @@ class Super_Custom_Post_Meta {
 			// array( 'meta_key' => 'active', 'name' => 'Active', 'type' => 'checkbox' )
 			$this->add_field( $field, $post_meta );
 		}
+
+		if ( $box['instructions_post'] ) {
+			echo '<div class="scpt-meta-instructions">' . $box['instructions_post'] . '</div>';	
+		}
+
 	}
 
 


### PR DESCRIPTION
Lets you add some content at the top and bottom of custom meta boxes by setting
`instructions_pre` and `instructions_post` properties on any `add_meta_box` calls.

Had to change how arguments are passed around to the meta box callback slightly to make it work.
