### PR TITLE
Replaced array_merge with array_merge_recursive in register_post_type()

### DIFF
--- a/includes/class-super-custom-post-type.php
+++ b/includes/class-super-custom-post-type.php
@@ -96,7 +96,7 @@ class Super_Custom_Post_Type extends Super_Custom_Post_Meta {
 			unset( $customizations['menu_icon'] ); # here we unset it because it will get set properly in the default array
 		}
 
-		$this->cpt = array_merge(
+		$this->cpt = array_merge_recursive(
 			apply_filters( 'scpt_plugin_default_cpt_options', array(
 				'label' => $this->plural,
 				'labels' => array(


### PR DESCRIPTION
This fixes an issue where values set in the 2nd dimension array 'labels'
were not being merged because array_merge only merges the 1st dimension
array elements.

The fix allows the user to customize a single element in the 'labels'
array and ensure that the Super CPT defaults apply to the remaining
sibling elements rather than have the WordPress defaults take precedence.
