### PR TITLE
Added meta field description as field_description

### DIFF
--- a/css/supercpt.css
+++ b/css/supercpt.css
@@ -57,7 +57,61 @@ select.scpt-field {
 	background: #fff;
 }
 
+.scpt-add-media,
+.scpt-remove-thumbnail {
+	background-color: #21759b;
+	background-image: -webkit-gradient(linear,left top,left bottom,from(#2a95c5),to(#21759b));
+	background-image: -webkit-linear-gradient(top,#2a95c5,#21759b);
+	background-image: -moz-linear-gradient(top,#2a95c5,#21759b);
+	background-image: -ms-linear-gradient(top,#2a95c5,#21759b);
+	background-image: -o-linear-gradient(top,#2a95c5,#21759b);
+	background-image: linear-gradient(to bottom,#2a95c5,#21759b);
+	border-color: #21759b;
+	border-bottom-color: #1e6a8d;
+	-webkit-box-shadow: inset 0 1px 0 rgba(120,200,230,.5);
+	box-shadow: inset 0 1px 0 rgba(120,200,230,.5);
+	color: #fff;
+	text-decoration: none;
+	text-shadow: 0 1px 0 rgba(0,0,0,.1);
+	display: inline-block;
+	text-decoration: none;
+	font-size: 12px;
+	line-height: 23px;
+	height: 24px;
+	margin: 0;
+	padding: 0 10px 1px;
+	cursor: pointer;
+	border-width: 1px;
+	border-style: solid;
+	-webkit-border-radius: 3px;
+	-webkit-appearance: none;
+	border-radius: 3px;
+	white-space: nowrap;
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
+}
 
+.scpt-add-media:hover,
+.scpt-remove-thumbnail:hover {
+	background-color: #278ab7;
+	background-image: -webkit-gradient(linear,left top,left bottom,from(#2e9fd2),to(#21759b));
+	background-image: -webkit-linear-gradient(top,#2e9fd2,#21759b);
+	background-image: -moz-linear-gradient(top,#2e9fd2,#21759b);
+	background-image: -ms-linear-gradient(top,#2e9fd2,#21759b);
+	background-image: -o-linear-gradient(top,#2e9fd2,#21759b);
+	background-image: linear-gradient(to bottom,#2e9fd2,#21759b);
+	border-color: #1b607f;
+	-webkit-box-shadow: inset 0 1px 0 rgba(120,200,230,.6);
+	box-shadow: inset 0 1px 0 rgba(120,200,230,.6);
+	color: #fff;
+	text-shadow: 0 -1px 0 rgba(0,0,0,.3);
+}
+
+.scpt-field-description {
+	color: #808080;
+	font-style: italic;
+}
 
 /* =Icon Madness
 -------------------------------------------------------------- */

--- a/includes/class-super-custom-post-meta.php
+++ b/includes/class-super-custom-post-meta.php
@@ -269,6 +269,7 @@ class Super_Custom_Post_Meta {
 		else
 			call_user_func( array( $this, "add_text_field" ), $field, $post_meta, $html_attributes );
 		echo '</', $this->field_wrapper, '>';
+		echo '<div class="scpt-field-description">' , $field['field_description'] . '</div>';
 	}
 
 	/*
@@ -636,7 +637,9 @@ class Super_Custom_Post_Meta {
 			'data' => true,
 			'prompt' => true,
 			'column' => true,
-			'default' => true
+			'default' => true,
+			'desc' => true,
+			'field_description' => true
 		) );
 	}
 


### PR DESCRIPTION
I have never contributed to a GIT project before so bear with me if this pull request isn't done right.

I tried to keep the usage as easy as possible. 

Usage:

```
$tests->add_meta_box( array(
    'id' => 'test-box',
    'context' => 'normal',
    'fields' => array(
        'test-field-one' => array('type'=>'text', 'field_description'=> 'Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Sed posuere consectetur est at lobortis. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.'),
        'test-field-two' => array('type'=>'media', 'field_description'=> 'Aenean lacinia bibendum nulla sed consectetur. Sed posuere consectetur est at lobortis.')
    )
) );
```

Renders:
![field_description-screenshot](https://f.cloud.github.com/assets/5108034/1609401/c237bb60-5541-11e3-9678-54d79c560895.png)
