### PR TITLE
replaced array_merge_recursive with array_replace_recursive

### DIFF
--- a/includes/class-super-custom-post-type.php
+++ b/includes/class-super-custom-post-type.php
@@ -96,7 +96,7 @@ class Super_Custom_Post_Type extends Super_Custom_Post_Meta {
 			unset( $customizations['menu_icon'] ); # here we unset it because it will get set properly in the default array
 		}
 
-		$this->cpt = array_merge_recursive(
+		$this->cpt = array_replace_recursive(
 			apply_filters( 'scpt_plugin_default_cpt_options', array(
 				'label' => $this->plural,
 				'labels' => array(


### PR DESCRIPTION
`array_merge_recursive` creates many issues with the config. `array_replace_recursive` resolves these issues and is meant to merge config arrays. Requires PHP 5.3+ 

Examples:

``` php
/* Setting custom "supports" */
$customize = array(
  'supports' => array( 'title', 'thumbnail' ),
);
$result = array_merge_recursive(array(
  'supports'  => array( 'title', 'editor', 'thumbnail', 'revisions', 'excerpt', 'page-attributes' ),
), $customize);

/* 
Expected result:
array(
  'supports'  => array( 'title', 'thumbnail' ),
)

Actual result:
array(
  'supports'  => array( 'title', 'editor', 'thumbnail', 'revisions', 'excerpt', 'page-attributes' ),
)
*/

/* Setting custom "has_archive" */
$customize = array(
  'has_archive' => 'recordings',
);
$result = array_merge_recursive(array(
  'has_archive' => true,
), $customize);

/* 
Expected result:
array(
 'has_archive' => 'recordings'
)

Actual result:
array(
 'has_archive' => array(
   true,
   'recordings'
 )
)
*/
```
