### PR TITLE
Hierarchical by default

### DIFF
--- a/includes/class-super-custom-post-type.php
+++ b/includes/class-super-custom-post-type.php
@@ -127,7 +127,7 @@ class Super_Custom_Post_Type extends Super_Custom_Post_Meta {
 				# 'show_in_menu'        => {value of show_ui},
 				# 'show_in_admin_bar'   => {value of show_in_menu}
 				# 'capability_type'     => 'post',
-				# 'hierarchical'        => false,
+				'hierarchical'        => true,
 				# 'rewrite'             => true,
 				# 'query_var'           => true,
 				# 'can_export'          => true,


### PR DESCRIPTION
This probably should be made an option but I don't see an issue with this being default. Having hierarchical post types by default can be very useful for event pages or major site sections.
